### PR TITLE
Fix IndexOutOfBounds and allow renaming existing pages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>de.sprengnetter.jenkins.plugins</groupId>
     <artifactId>confluence-pipeline-steps</artifactId>
-    <version>0.3.2</version>
+    <version>0.3.3</version>
     <packaging>hpi</packaging>
     <name>Confluence Pipeline Steps Plugin</name>
     <inceptionYear>2017</inceptionYear>

--- a/src/main/java/de/sprengnetter/jenkins/plugins/jenfluence/step/descriptor/UpdatePageStep.java
+++ b/src/main/java/de/sprengnetter/jenkins/plugins/jenfluence/step/descriptor/UpdatePageStep.java
@@ -13,14 +13,18 @@ import javax.annotation.Nonnull;
 public class UpdatePageStep extends AbstractStep {
     private static final long serialVersionUID = -7249517566943303127L;
 
+    private String spaceKey;
     private String title;
+    private String newTitle;
     private String newContent;
     private boolean append;
 
     @DataBoundConstructor
-    public UpdatePageStep(String title, String newContent, boolean append) {
+    public UpdatePageStep(String spaceKey, String title, String newTitle, String newContent, boolean append) {
         super();
+        this.spaceKey = spaceKey;
         this.title = title;
+        this.newTitle = newTitle;
         this.newContent = newContent;
         this.append = append;
     }
@@ -30,8 +34,16 @@ public class UpdatePageStep extends AbstractStep {
         return new UpdatePageStepExecution(this, context, getSite());
     }
 
+    public String getSpaceKey() {
+        return spaceKey;
+    }
+
     public String getTitle() {
         return title;
+    }
+
+    public String getNewTitle() {
+        return newTitle;
     }
 
     public String getNewContent() {

--- a/src/main/java/de/sprengnetter/jenkins/plugins/jenfluence/step/execution/AttachFileExecution.java
+++ b/src/main/java/de/sprengnetter/jenkins/plugins/jenfluence/step/execution/AttachFileExecution.java
@@ -24,6 +24,10 @@ public class AttachFileExecution extends AbstractStepExecution<String, AttachFil
     protected String run() {
         ContentService service = getService(ContentService.class);
         Content pageContent = service.getPage(getStep().getSpaceKey(), getStep().getTitle(), null);
+        if(pageContent.getResults().size() == 0 || pageContent.getResults().get(0).getId() == 0) {
+            throw new IllegalStateException("Page with title " + getStep().getTitle() + " not found in space" +
+                    getStep().getSpaceKey());
+        }
         return service.attachFile(String.valueOf(pageContent.getResults().get(0).getId()),
                 getStep().getFilePath());
     }

--- a/src/main/java/de/sprengnetter/jenkins/plugins/jenfluence/step/execution/CreatePageExecution.java
+++ b/src/main/java/de/sprengnetter/jenkins/plugins/jenfluence/step/execution/CreatePageExecution.java
@@ -102,7 +102,7 @@ public class CreatePageExecution extends AbstractStepExecution<PageCreated, Crea
         ContentService service = getService(ContentService.class);
         Content content = service.getPage(getStep().getSpaceKey(), getStep().getBy().getParentIdentifier(), null);
 
-        if (content.getResults().get(0).getId() == null || content.getResults().size() == 0) {
+        if (content.getResults().size() == 0 || content.getResults().get(0).getId() == null) {
             throw new IllegalStateException("No parent page with name " + getStep().getBy().getParentIdentifier() + " in space with key "
                     + getStep().getSpaceKey() + " was found");
         }

--- a/src/main/resources/de/sprengnetter/jenkins/plugins/jenfluence/step/descriptor/UpdatePageStep/config.jelly
+++ b/src/main/resources/de/sprengnetter/jenkins/plugins/jenfluence/step/descriptor/UpdatePageStep/config.jelly
@@ -10,22 +10,30 @@
         xmlns:i="jelly:fmt">
 
     <f:section title="General">
-        <f:entry field="title" title="Page title" description="The new title of the page">
+        <f:entry field="spaceKey" title="Space key" description="The key of the space in which the page is located">
             <f:textbox/>
+        </f:entry>
+
+        <f:entry field="title" title="Page title" description="Current title of the page">
+            <f:textbox/>
+        </f:entry>
+
+        <f:entry field="append" description="Append to existing page/Override existing content">
+            <f:checkbox name="append" checked="false" title="Append new Content to page"
+                        default="false">
+            </f:checkbox>
         </f:entry>
     </f:section>
 
-    <f:entry field="append" description="Append to existing page/Override existing content">
-        <f:checkbox name="append" checked="false" title="Append new Content to page"
-                    default="false">
-        </f:checkbox>
-    </f:entry>
-
     <f:section title="Content">
+        <f:entry field="newTitle" title="New page title" description="The new title of the page">
+            <f:textbox/>
+        </f:entry>
+
         <f:block>
-            <p>Type the new content of the page in the textbox below. It is also possible to pass HTML code if you want
-                to
-                format your content.
+            <p>
+                Type the new content of the page in the textbox below. It is also possible to pass HTML code if you want
+                to format your content.
             </p>
         </f:block>
         <f:entry field="newContent" title="Page content" description="The content of the created page">

--- a/src/main/resources/de/sprengnetter/jenkins/plugins/jenfluence/step/descriptor/UpdatePageStep/help-newTitle.html
+++ b/src/main/resources/de/sprengnetter/jenkins/plugins/jenfluence/step/descriptor/UpdatePageStep/help-newTitle.html
@@ -1,0 +1,3 @@
+<div align="center">
+    The new title of the Confluence page to update.
+</div>

--- a/src/main/resources/de/sprengnetter/jenkins/plugins/jenfluence/step/descriptor/UpdatePageStep/help-spaceKey.html
+++ b/src/main/resources/de/sprengnetter/jenkins/plugins/jenfluence/step/descriptor/UpdatePageStep/help-spaceKey.html
@@ -1,0 +1,12 @@
+<div>
+    <p>
+        This is the key of the space where the page resides. Usually it is a short form of the title of the space. If
+        you have no clue where to find the key you can visit the space in your browser and extract the key from the URL.
+    </p>
+    <p>It will look like this:</p>
+    <ul>
+        <em>http://$host/display/<strong>KEY</strong>/.../...</em>
+    </ul>
+
+    <p>Copy that key and paste it in here.</p>
+</div>

--- a/src/main/resources/de/sprengnetter/jenkins/plugins/jenfluence/step/descriptor/UpdatePageStep/help-title.html
+++ b/src/main/resources/de/sprengnetter/jenkins/plugins/jenfluence/step/descriptor/UpdatePageStep/help-title.html
@@ -1,3 +1,3 @@
 <div align="center">
-    The title of the Confluence page which is going to be created.
+    The current title of the Confluence page to update.
 </div>


### PR DESCRIPTION
This PR addresses several issues:

1. Fixes IndexOutOfBounds exception in create page step if the specified parent page is not found
2. Fixes IndexOutOfBounds exception in attach file step if the specified page is not found
3. Address plugin's inability to handle multiple pages with the same title in different spaces by requiring spaceKey for updating a page. In Confluence, page title is unique within a space, but not across the instance.
4. Adds the ability to rename a page using update page step and specifying a new title. If the new title is not specified, the existing one is kept.
